### PR TITLE
Topics and sessions expandable

### DIFF
--- a/packages/app/src/hooks/useSpringTransition.ts
+++ b/packages/app/src/hooks/useSpringTransition.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'react'
+import { useDerivedValue, useSharedValue, withSpring } from 'react-native-reanimated'
+
+export const useSpringTransition = (isOpen?: boolean, height?: number) => {
+  const value = useSharedValue(isOpen && height ? height : 0)
+
+  useEffect(() => {
+    if (height) {
+      value.value = isOpen ? height : 0
+    }
+  }, [isOpen, value, height])
+
+  return useDerivedValue(() => {
+    return withSpring(value.value, { damping: 15 })
+  })
+}

--- a/packages/app/src/screens/TabsNavigation/screens/Schedule/components/Session/components/Block.tsx
+++ b/packages/app/src/screens/TabsNavigation/screens/Schedule/components/Session/components/Block.tsx
@@ -5,7 +5,6 @@ import { Maybe, Scalars, SpeakerFragment } from '@-local/db/lib/api'
 import Text from 'components/Text'
 import styled from '@emotion/native'
 import useShadow from 'hooks/useShadow'
-import { TouchableOpacity } from 'react-native-gesture-handler'
 import ExtendedInfo from './ExtendedInfo'
 
 type SessionProps = {
@@ -22,7 +21,6 @@ const Block: FC<SessionProps> = ({
   title,
   description,
   begins_at,
-  /*ends_at,*/
   children,
   speaker,
   location,
@@ -36,7 +34,6 @@ const Block: FC<SessionProps> = ({
         <Info>
           <SessionName>{title}</SessionName>
           {begins_at && <SessionTime>{format(parseISO(begins_at), 'HH:mm')}</SessionTime>}
-          {/* {ends_at && <Text>{format(parseISO(ends_at), 'HH:mm')}</Text>} */}
         </Info>
       }
 
@@ -53,15 +50,7 @@ export const Wrapper = styled.View<{ withTopics?: boolean; muted?: boolean }>`
   padding-bottom: 2px; /* NOTE: font bug compensation */
 `
 
-const Info = styled.View`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
-  padding: ${({ theme }) => `${theme.spacing.m}px`};
-`
-
-export const TouchableInfo = styled(TouchableOpacity)`
+export const Info = styled.View`
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/packages/app/src/screens/TabsNavigation/screens/Schedule/components/Session/components/ExtendedInfo.tsx
+++ b/packages/app/src/screens/TabsNavigation/screens/Schedule/components/Session/components/ExtendedInfo.tsx
@@ -1,10 +1,15 @@
-import React, { FC } from 'react'
+import React, { FC, useRef, useState } from 'react'
 import styled from '@emotion/native'
+import { useTheme } from '@react-navigation/native'
+import { MaterialIcons } from '@expo/vector-icons'
+import Animated, { useAnimatedStyle } from 'react-native-reanimated'
+import { TouchableOpacity, View } from 'react-native'
 
 import { Maybe, Scalars, SpeakerFragment } from '@-local/db/lib/api'
 import Text from 'components/Text'
 import Location from './Location'
 import Speaker from './Speaker'
+import { useSpringTransition } from 'hooks/useSpringTransition'
 
 type ExtendedInfoProps = {
   description?: Maybe<Scalars['String']>
@@ -17,22 +22,50 @@ export const ExtendedInfo: FC<ExtendedInfoProps> = ({
   speaker,
   location,
   children,
-}) => (
-  <>
-    {description && (
-      <DescriptionSection>
-        <DescriptionText>{description}</DescriptionText>
-      </DescriptionSection>
-    )}
-    {location || speaker ? (
-      <SpeakerAndLocation>
-        {location && <Location>{location}</Location>}
-        {speaker && <Speaker {...speaker} />}
-      </SpeakerAndLocation>
-    ) : null}
-    {children}
-  </>
-)
+}) => {
+  const isExpandable = useRef(!!(description || location || speaker))
+  const theme = useTheme()
+  const [isOpen, setIsOpen] = useState<boolean>(!isExpandable.current)
+  const [height, setHeight] = useState<number>()
+  const transition = useSpringTransition(isOpen, height)
+  const style = useAnimatedStyle(() => ({
+    height: transition.value,
+  }))
+
+  return (
+    <>
+      <Animated.View style={[{ overflow: 'hidden' }, style]}>
+        <View
+          onLayout={(event) => {
+            setHeight(event?.nativeEvent?.layout?.height)
+          }}
+        >
+          {description && (
+            <DescriptionSection>
+              <DescriptionText>{description}</DescriptionText>
+            </DescriptionSection>
+          )}
+          {location || speaker ? (
+            <SpeakerAndLocation>
+              {location && <Location>{location}</Location>}
+              {speaker && <Speaker {...speaker} />}
+            </SpeakerAndLocation>
+          ) : null}
+        </View>
+        {children}
+      </Animated.View>
+      {isExpandable.current && (
+        <TouchableExpandButton onPress={() => setIsOpen(!isOpen)}>
+          <MaterialIcons
+            name={isOpen ? 'keyboard-arrow-up' : 'keyboard-arrow-down'}
+            size={24}
+            color={theme.colors.text}
+          />
+        </TouchableExpandButton>
+      )}
+    </>
+  )
+}
 
 const DescriptionSection = styled.View`
   padding: ${({ theme }) => `0 ${theme.spacing.m}px ${theme.spacing.l}px`};
@@ -46,6 +79,14 @@ const SpeakerAndLocation = styled.View`
   display: flex;
   flex-direction: row-reverse;
   align-items: center;
+`
+
+const TouchableExpandButton = styled(TouchableOpacity)`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  padding: ${({ theme }) => `${theme.spacing.xxs}px`};
 `
 
 export default ExtendedInfo

--- a/packages/app/src/screens/TabsNavigation/screens/Schedule/components/Session/components/TopicBlock.tsx
+++ b/packages/app/src/screens/TabsNavigation/screens/Schedule/components/Session/components/TopicBlock.tsx
@@ -1,16 +1,9 @@
-import React, { FC, useEffect, useState } from 'react'
-import { View } from 'react-native'
-import Animated, {
-  useAnimatedStyle,
-} from 'react-native-reanimated'
-import { useTheme } from '@react-navigation/native'
-import { MaterialIcons } from '@expo/vector-icons'
+import React, { FC } from 'react'
 
 import { Maybe, Scalars, SpeakerFragment } from '@-local/db/lib/api'
 import Text from 'components/Text'
 import useShadow from 'hooks/useShadow'
-import { TouchableInfo, Wrapper } from './Block'
-import { useSpringTransition } from 'hooks/useSpringTransition'
+import { Info, Wrapper } from './Block'
 import ExtendedInfo from './ExtendedInfo'
 
 type SessionProps = {
@@ -26,41 +19,19 @@ type SessionProps = {
 const TopicBlock: FC<SessionProps> = ({
   title,
   description,
-  /*ends_at,*/
   children,
   speaker,
   location,
   muted,
 }) => {
-  const theme = useTheme()
   const shadow = useShadow(2)
-  const [isOpen, setIsOpen] = useState<boolean>()
-  const [height, setHeight] = useState<number>()
-  const transition = useSpringTransition(isOpen, height)
-  const style = useAnimatedStyle(() => ({
-    height: transition.value,
-  }))
 
   return (
     <Wrapper style={!muted ? shadow : {}} muted={muted}>
-      <TouchableInfo onPress={() => setIsOpen(!isOpen)}>
+      <Info>
         <Text>{title}</Text>
-        <MaterialIcons
-          name={isOpen ? 'unfold-less' : 'unfold-more'}
-          size={24}
-          color={theme.colors.text}
-        />
-      </TouchableInfo>
-
-      <Animated.View style={[{ overflow: 'hidden' }, style]}>
-        <View
-          onLayout={(event) => {
-            setHeight(event?.nativeEvent?.layout?.height)
-          }}
-        >
-          <ExtendedInfo {...{ description, location, speaker, children }} />
-        </View>
-      </Animated.View>
+      </Info>
+      <ExtendedInfo {...{ description, location, speaker, children }} />
     </Wrapper>
   )
 }

--- a/packages/app/src/screens/TabsNavigation/screens/Schedule/components/Session/components/TopicBlock.tsx
+++ b/packages/app/src/screens/TabsNavigation/screens/Schedule/components/Session/components/TopicBlock.tsx
@@ -2,9 +2,6 @@ import React, { FC, useEffect, useState } from 'react'
 import { View } from 'react-native'
 import Animated, {
   useAnimatedStyle,
-  useDerivedValue,
-  useSharedValue,
-  withSpring,
 } from 'react-native-reanimated'
 import { useTheme } from '@react-navigation/native'
 import { MaterialIcons } from '@expo/vector-icons'
@@ -13,6 +10,7 @@ import { Maybe, Scalars, SpeakerFragment } from '@-local/db/lib/api'
 import Text from 'components/Text'
 import useShadow from 'hooks/useShadow'
 import { TouchableInfo, Wrapper } from './Block'
+import { useSpringTransition } from 'hooks/useSpringTransition'
 import ExtendedInfo from './ExtendedInfo'
 
 type SessionProps = {
@@ -23,20 +21,6 @@ type SessionProps = {
   ends_at?: Maybe<Scalars['timestamptz']>
   speaker?: Maybe<SpeakerFragment>
   muted?: boolean
-}
-
-const useSpringTransition = (isOpen?: boolean, height?: number) => {
-  const value = useSharedValue(isOpen && height ? height : 0)
-
-  useEffect(() => {
-    if (height) {
-      value.value = isOpen ? height : 0
-    }
-  }, [isOpen, value, height])
-
-  return useDerivedValue(() => {
-    return withSpring(value.value, { damping: 15 })
-  })
 }
 
 const TopicBlock: FC<SessionProps> = ({


### PR DESCRIPTION
As requested, now everything is expandable (topics as well as sessions). The expand arrow shows only when at least one of the descriptions, speakers, or locations is present.

![image](https://user-images.githubusercontent.com/25500609/123844030-d3252e00-d912-11eb-8a20-8b66b464dd21.png)
