### PR TITLE
fix: Moved children out of expandable view

### DIFF
--- a/packages/app/src/screens/TabsNavigation/screens/Schedule/components/Session/components/ExtendedInfo.tsx
+++ b/packages/app/src/screens/TabsNavigation/screens/Schedule/components/Session/components/ExtendedInfo.tsx
@@ -52,8 +52,8 @@ export const ExtendedInfo: FC<ExtendedInfoProps> = ({
             </SpeakerAndLocation>
           ) : null}
         </View>
-        {children}
       </Animated.View>
+      {children}
       {isExpandable.current && (
         <TouchableExpandButton onPress={() => setIsOpen(!isOpen)}>
           <MaterialIcons


### PR DESCRIPTION
By mistake, I moved `children` into the Animated.View that was hidden if no description and speaker are present. This commit fixes it.